### PR TITLE
Desktop User-Agent for Bilibili Manga

### DIFF
--- a/src/all/bilibili/build.gradle
+++ b/src/all/bilibili/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'BILIBILI'
     pkgNameSuffix = 'all.bilibili'
     extClass = '.BilibiliFactory'
-    extVersionCode = 6
+    extVersionCode = 7
 }
 
 dependencies {

--- a/src/all/bilibili/src/eu/kanade/tachiyomi/extension/all/bilibili/Bilibili.kt
+++ b/src/all/bilibili/src/eu/kanade/tachiyomi/extension/all/bilibili/Bilibili.kt
@@ -54,6 +54,7 @@ abstract class Bilibili(
     override fun headersBuilder(): Headers.Builder = Headers.Builder()
         .add("Accept", ACCEPT_JSON)
         .add("Origin", baseUrl)
+        .add("User-Agent", if(apiLang == "cn") "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36" else System.getProperty("http.agent")!!)
         .add("Referer", "$baseUrl/")
 
     private val apiLang: String = when (lang) {


### PR DESCRIPTION
This should make it possible to sign in to manga.bilibili.com, as the desktop user-agent is used.

Note that I'm green hand at Kotlin and this PR is made in browser and not tested. Also, the user-agent string is hard-coded and should be replaced later.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
